### PR TITLE
Adding id to rag file model and using this in delete and status update operations

### DIFF
--- a/app/api/rag/delete-file/route.ts
+++ b/app/api/rag/delete-file/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const fileCollection = db.collection<RagFile>('files');
 
     const fileDeletedFromDB = await fileCollection.deleteOne({
-      ragId: file.ragId,
+      id: file.id,
     });
     const fileDeletedFromDisk = await fs.unlink(file.path);
     return NextResponse.json({

--- a/app/api/rag/update-file-status/route.ts
+++ b/app/api/rag/update-file-status/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     await fileCollection.updateOne(
       {
-        ragId: file.ragId,
+        id: file.id,
       },
       {
         $set: {

--- a/app/models/File.ts
+++ b/app/models/File.ts
@@ -10,6 +10,7 @@ interface RagFile {
   name: string;
   path: string;
   ragId: string;
+  id: string;
   purpose: string;
   processed: boolean;
   chunks: string[];


### PR DESCRIPTION
Problem:

Issue #92 

Inconsistencies in vector db when deleting rag files from the front end. When the user has multiple rag files uploaded and chooses to delete one, it is seemingly random which files are actually deleted when refreshing the page.

When trying to process uploaded rag files only the respective entry in the vector db for the originally uploaded file will update. This means when you process further files and refresh the application, they appear on the front end as if they have not already been processed.


Cause:
RAG API Operations delete-file and update-file-status are both using the ragId field in fileCollection.deleteOne() and fileCollection.updateOne() respectively. This ragId is defined on the user and assigned to all files that user uploads, meaning it is not unique to each file separately and causes inconsistencies in these operations that are trying to operate on specific files.

Solution:
Added id to rag file model in File.ts and replaced usages of ragId with this id that is unique to each file when trying to operate on specific rag files.